### PR TITLE
Close channel after parsing

### DIFF
--- a/lib/openQASM.ml
+++ b/lib/openQASM.ml
@@ -18,7 +18,9 @@ let parse_with_error lexbuf =
 
 (* core parsing routine *)
 let get_ast f =
-  let lexbuf = Lexing.from_channel (open_in f) in
+  let ic = open_in f in
+  let lexbuf = Lexing.from_channel ic in
+  close_in ic;
   parse_with_error lexbuf
 
 module AST = AST

--- a/lib/openQASM.ml
+++ b/lib/openQASM.ml
@@ -7,20 +7,19 @@ let print_position outx lexbuf =
   fprintf outx "%s:%d:%d" pos.pos_fname
     pos.pos_lnum (pos.pos_cnum - pos.pos_bol + 1)
 
-let parse_with_error lexbuf =
-  try Parser.mainprogram Lexer.token lexbuf with
-  | Lexer.SyntaxError msg ->
-      fprintf stderr "%a: %s\n" print_position lexbuf msg;
-      []
-  | Parser.Error ->
-      fprintf stderr "%a: syntax error\n" print_position lexbuf;
-      exit (-1)
-
 (* core parsing routine *)
 let get_ast f =
   let ic = open_in f in
   let lexbuf = Lexing.from_channel ic in
+  let res = (try Parser.mainprogram Lexer.token lexbuf with
+            | Lexer.SyntaxError msg ->
+                fprintf stderr "%a: %s\n" print_position lexbuf msg;
+                []
+            | Parser.Error ->
+                fprintf stderr "%a: syntax error\n" print_position lexbuf;
+                close_in ic;
+                exit (-1)) in
   close_in ic;
-  parse_with_error lexbuf
+  res
 
 module AST = AST


### PR DESCRIPTION
While running an experiment for VOQC, I got an OS Error about "too many open files". After some debugging, I determined that this was because the OpenQASM parser is opening files without closing them. With the changes in this PR, I don't get the OS Error, and I haven't broken anything in the parser AFAICT.

Note: This problem may only manifest in my strange use case of calling Python -> C -> OCaml in [pyvoqc](https://github.com/inQWIRE/pyvoqc), but it's probably good practice to close the channel anyways.